### PR TITLE
This closes #38

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,9 @@ jobs:
     language: python
     python:
       - "3.6"
-    if: (branch=master) AND (type IN (push, api, cron))
+    if: (branch=master) AND (type IN (push, api))
     install:
-    - pip3 install pipenv
+    - python3 -m pip install pipenv
     script:
     - python3 build-deploy.py
     - python3 test.py pytest
@@ -40,19 +40,33 @@ jobs:
       deployment_file: true
       verbose: true
       github_token: "$GITHUB_TOKEN"
+  - name: cron_build
+    language: python
+    python:
+      - "3.6"
+      - "3.7"
+      - "3.8"
+      - "3.9"
+      - "nightly"
+    if: (branch=master) AND (type IN (cron))
+    install:
+    - python3 -m pip install pipenv
+    script:
+    - python3 build-cron.py
+    - python3 test.py pytest
   - name: merge_build
     language: python
     python:
       - "3.6"
     if: (branch=master) AND (type IN (pull_request))
     install:
-    - pip3 install pipenv
+    - python3 -m pip install pipenv
     script:
     - python3 build-merge.py
     - python3 test.py pytest
   - name: markdown_lint
     language: node_js
-    if: (branch=master) AND (type IN (pull_request))
+    if: (branch=master) AND (type IN (pull_request, cron))
     node_js:
     - node
     before_script:

--- a/build-cron.py
+++ b/build-cron.py
@@ -1,0 +1,9 @@
+#!/usr/bin/python3
+
+# This script build the site for scheduled checks which are not intended to
+# deploy
+
+import subprocess
+
+subprocess.run(["pipenv", "install"])
+subprocess.run(["pipenv", "run", "mkdocs", "build", "--clean", "--strict", "--verbose", "--config-file", "mkdocs-cron.yml"], check=True)

--- a/mkdocs-cron.yml
+++ b/mkdocs-cron.yml
@@ -27,6 +27,7 @@ plugins:
       bib_file: "ref/refs.bib"
       cite_style: "pandoc"
   - git-revision-date
+  - htmlproofer
   - search
   - mkdocs-simple-hooks:
       hooks:


### PR DESCRIPTION
* Seperate build is created for cron job which includes htmlproofer
plugin. The plugin is removed from merge request checks
* For cron job, different python versions than 3.6 are added to build
matrix

Fixes #38 

...

Ping @alperyazar
