### PR TITLE
Add .editorconfig to project

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+end_of_line = lf
+
+[*.{js,yml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = true

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -17,6 +17,8 @@
         // Easy indentation
         "oderwat.indent-rainbow",
         // Bracket pairing
-        "coenraads.bracket-pair-colorizer-2"
+        "coenraads.bracket-pair-colorizer-2",
+        // .editorconfig
+        "EditorConfig.EditorConfig"
     ]
 }

--- a/.vscode/settings.json.recommended
+++ b/.vscode/settings.json.recommended
@@ -1,7 +1,6 @@
 {
     "cSpell.language": "en,tr",
     "cSpell.logLevel": "Information",
-    "files.eol": "\n",
     "editor.rulers": [
     80
     ]


### PR DESCRIPTION
This fixes #64

Unlike other projects, I enable trim_trailing_whitespace for *.md files
because our linter doesn't like it and we don't use double space to
break the line.

I remove eol setting from recommended VS Code settings since it will be
applied by the editorconfig. Added VS Code editorconfig to recommended
extension

Fixes #64 

...

Ping @alperyazar
