### PR TITLE
Revise markdown linter settings

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,15 +1,41 @@
 {
+  # Enable all markdownlint rules
   "default": true,
-  "MD013": true,
+
+  # Allow only # Header style
+  "MD003": {"style": "atx"},
+
+  # Set list indent level to 4 which Python-Markdown requires
+  "MD007": { "indent": 4 },
+
+  # Max line length is 80, exceptions: code blocks and tables
+  "MD013": { "line_length": 80, "code_blocks": false, "tables": false },
+
+  # MD014 - Dollar signs used before commands without showing output
   "MD014": false,
-  "MD024": {
-    "siblings_only": true # Allowed for non-sibling headings. See: https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md024
-  },
-  "MD026": {
-    "punctuation": ".,;:" # Allow ! and ?
-  },
-  "MD033": {
-    "allowed_elements": ["iframe", "pre"] # For YouTube videos. See: https://github.com/DavidAnson/markdownlint/blob/2d8122a3bec9d33c55da5620d07901842fb9c92d/test/inline_html-allowed_elements.json
-  },
-  "MD036":false
+
+  # Allowed for non-sibling headings. See: https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md024
+  "MD024": { "siblings_only": true },
+
+  # Allow ! and ?
+  "MD026": { "punctuation": ".,;:" },
+
+  # Set Ordered list item prefix to "ordered" (use 1. 2. 3. not 1. 1. 1.)
+  "MD029": { "style": "ordered" },
+
+  # None
+  # If needed see: For YouTube videos. See: https://github.com/DavidAnson/markdownlint/blob/2d8122a3bec9d33c55da5620d07901842fb9c92d/test/inline_html-allowed_elements.json
+  "MD033": { "allowed_elements": [""] },
+
+  # hr is ---
+  "MD035": { "style": "---" },
+
+  # MD036 - Emphasis used instead of a heading
+  "MD036": false,
+
+  # Allow fenced ``` code block style (with MD048)
+  "MD046": { "style": "fenced"},
+
+  # ``` is code block style
+  "MD048": { "style": "backtick"}
 }

--- a/docs/blog/20/0-mig-calibration-error-xilinx.md
+++ b/docs/blog/20/0-mig-calibration-error-xilinx.md
@@ -31,14 +31,14 @@ parameters especially PL memory port configuration, which can confuse a person
 so much. Therefore, if you have a problem with `init_calib_complete` signal,
 you should check your MIG configuration. I have listed the most important
 parameters and stages that you should be careful about below:
-<!--markdownlint-disable MD013-->
+
 Page Name|Setting Name|Instruction
 ---------------|-----------|---------------------------------------------------------
 **Options for Controller**|**Clock Period Parameter**|You should know which frequency at most your PL memory can reach. Otherwise, because if your PL memory does not support the frequency that it can, probably you will not be able to make your memory work.
 **Options for Controller**|**Memory Part**| For your FPGA, there are many Xilinx documents that you can learn which memory part your FPGA's PL memory utilizes. You should search and choose the right one.
 **Memory Options for Controller**|**Input Clock Period**|In addition to the memory part, you should also search about the system clock frequency and choose the right period.
 **Pin Selection for Controller**|-|This part is the most confusing and important part for MIG configuration. Again, you should search about the ports and connect ports correctly. This situation is the same for when you choose the ports for `sys_clk`, `clk_ref` and `sys_rst` signals in "**System Signals Selection**" part.
-<!--markdownlint-enable MD013-->
+
 **2)** **Check All Resets** → There are 3 resets in MIG, which are `sys_rst`,
 `aresetn` and `ui_clk_sync_rst`. If you do not connect `sys_rst pin` to a port
 from your FPGA and you want to give it a signal, do not choose `ui_clk_sync_rst`


### PR DESCRIPTION
This fixes #66

Rules are revised according to current rules written on
https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md

Since tables are excluded for rule MD013 with config, temporary
disabling the rule is removed from .md files

Fixes # .

...

Ping @alperyazar
Ping @yunusesergun Tablolar için geçici olarak MD013 disable etmek gerekmeyecek artık.
