### PR TITLE
fix title capitalization style

### DIFF
--- a/src/_posts/2020-12-07-getting-started-to-vitis-acceleration-flow-with-zynq-7000.md
+++ b/src/_posts/2020-12-07-getting-started-to-vitis-acceleration-flow-with-zynq-7000.md
@@ -1,6 +1,6 @@
 ---
-title: "Getting Started to Vitis Acceleration Flow with Zynq 7000"
-excerpt: "Getting Started to Vitis Acceleration Flow with Zynq 7000."
+title: "Getting started to Vitis acceleration flow with Zynq 7000"
+excerpt: "Getting started to Vitis acceleration flow with Zynq 7000."
 categories:
     - tutorial
 tags:

--- a/src/_posts/2021-02-07-jekyll.md
+++ b/src/_posts/2021-02-07-jekyll.md
@@ -1,5 +1,5 @@
 ---
-title: "Jekyll'ye Geçiş"
+title: "Jekyll'ye geçiş"
 excerpt: "mkdocs'tan Jekyll'ye geçiş"
 categories:
     - news


### PR DESCRIPTION
This PR adds new feature, fixes something that isn't linked to any opened issue.

**Only first letter of titles are capital in our style.**
